### PR TITLE
Fix qualified import bug

### DIFF
--- a/src/DeriveHasField.hs
+++ b/src/DeriveHasField.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module DeriveHasField (
-  module GHC.Records,
   deriveHasFieldWith,
 )
 where
@@ -56,7 +55,7 @@ makeDeriveHasField fieldModifier datatypeInfo = do
         litTFieldWanted = litT $ strTyLit wantedFieldName
      in if currentFieldName == wantedFieldName
           then fail "deriveHasField: after applying fieldModifier, field didn't change"
-          else do
+          else
             [d|
               instance HasField $litTFieldWanted $parentType $(pure ty) where
                 getField = $(appTypeE (varE 'getField) litTCurrentField)

--- a/src/DeriveHasField.hs
+++ b/src/DeriveHasField.hs
@@ -56,10 +56,10 @@ makeDeriveHasField fieldModifier datatypeInfo = do
         litTFieldWanted = litT $ strTyLit wantedFieldName
      in if currentFieldName == wantedFieldName
           then fail "deriveHasField: after applying fieldModifier, field didn't change"
-          else
+          else do
             [d|
               instance HasField $litTFieldWanted $parentType $(pure ty) where
-                getField = $(appTypeE (varE $ mkName "getField") litTCurrentField)
+                getField = $(appTypeE (varE 'getField) litTCurrentField)
               |]
   pure $ Foldable.concat decs
 

--- a/test/DeriveHasFieldSpec.hs
+++ b/test/DeriveHasFieldSpec.hs
@@ -6,7 +6,7 @@
 module DeriveHasFieldSpec where
 
 import Data.Data (Proxy (..))
-import DeriveHasField
+import DeriveHasField qualified
 import GHC.TypeLits (Symbol)
 import Import
 import Test.Hspec
@@ -18,7 +18,7 @@ data SomeType = SomeType
   , someTypeSomeEitherField :: Either String Int
   }
 
-deriveHasFieldWith (dropPrefix "someType") ''SomeType
+DeriveHasField.deriveHasFieldWith (dropPrefix "someType") ''SomeType
 
 someType :: SomeType
 someType =
@@ -34,7 +34,7 @@ data OtherType a b = OtherType
   , otherTypeOtherField :: Either a b
   }
 
-deriveHasFieldWith (dropPrefix "otherType") ''OtherType
+DeriveHasField.deriveHasFieldWith (dropPrefix "otherType") ''OtherType
 
 otherType :: OtherType Int String
 otherType =
@@ -48,7 +48,7 @@ data KindedType (kind :: * -> *) (sym :: Symbol) = KindedType
   , kindedTypeWithSymbol :: Proxy sym
   }
 
-deriveHasFieldWith (dropPrefix "kindedType") ''KindedType
+DeriveHasField.deriveHasFieldWith (dropPrefix "kindedType") ''KindedType
 
 kindedType :: KindedType Maybe "hello"
 kindedType =


### PR DESCRIPTION
Closes #7 

We shouldn't construct the name from scratch. We should instead use the name from our own environment to construct the `Name`.