### PR TITLE
Use type constructor instead of data constructor, add haddock

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ data BankAccount =
 
 deriveHasField ''BankAccount
 
--- alternatively, for prefixes that don't match the data constructor name
+-- alternatively, for prefixes that don't match the type name
 deriveHasFieldWith (dropPrefix "bankAccount") ''BankAccount
 ```
 

--- a/src/DeriveHasField.hs
+++ b/src/DeriveHasField.hs
@@ -20,7 +20,7 @@ import Language.Haskell.TH
 import Language.Haskell.TH.Datatype
 
 {- |
-Removes the type's name as a prefix on all fields
+Runs a function on all fields to generate HasField instances
 
 If you just want to use the name of the type as a prefix, see 'deriveHasField'
 

--- a/test/DeriveHasFieldSpec.hs
+++ b/test/DeriveHasFieldSpec.hs
@@ -103,6 +103,21 @@ kindedTypePrefix =
     , kindedTypePrefixWithSymbol = Proxy @"hello"
     }
 
+-- mismatched type constructor and data constructor name
+data TypeConstructor = DataConstructor
+  { typeConstructorField :: String
+  , typeConstructorOtherField :: Int
+  }
+
+DeriveHasField.deriveHasField ''TypeConstructor
+
+typeConstructorValue :: TypeConstructor
+typeConstructorValue =
+  DataConstructor
+    { typeConstructorField = "hello"
+    , typeConstructorOtherField = 0
+    }
+
 spec :: Spec
 spec = do
   describe "deriveHasField" $ do
@@ -117,6 +132,9 @@ spec = do
     it "compiles and gets the right field" $ do
       kindedType.withKind `shouldBe` Just ()
       kindedType.withSymbol `shouldBe` Proxy @"hello"
+    it "works with a mismatched type constructor and data constructor name" $ do
+      typeConstructorValue.field `shouldBe` "hello"
+      typeConstructorValue.otherField `shouldBe` 0
 
   describe "deriveHasFieldWith" $ do
     it "compiles and gets the right field" $ do


### PR DESCRIPTION
Using the type name means `deriveHasField ''CoolConstructor` will always strip off the prefix `coolConstructor`, which seems like more obvious behavior