### PR TITLE
Enforce data and type constructors are the same String

### DIFF
--- a/derive-has-field.cabal
+++ b/derive-has-field.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           derive-has-field
-version:        0.0.1.6
+version:        0.1.0.0
 synopsis:       Derive HasField instances with Template Haskell
 description:    A Template Haskell function to derive HasField instances to utilize OverloadedRecordDot more effectively.
 category:       Template Haskell

--- a/derive-has-field.cabal
+++ b/derive-has-field.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           derive-has-field
-version:        0.0.1.5
+version:        0.0.1.6
 synopsis:       Derive HasField instances with Template Haskell
 description:    A Template Haskell function to derive HasField instances to utilize OverloadedRecordDot more effectively.
 category:       Template Haskell

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:    derive-has-field
-version: 0.0.1.6
+version: 0.1.0.0
 github: "chiroptical/derive-has-field"
 license: MIT
 author: "Barry Moore II"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:    derive-has-field
-version: 0.0.1.5
+version: 0.0.1.6
 github: "chiroptical/derive-has-field"
 license: MIT
 author: "Barry Moore II"

--- a/src/DeriveHasField.hs
+++ b/src/DeriveHasField.hs
@@ -28,6 +28,8 @@ deriveHasField name = do
   constructorInfo <- case datatypeInfo.datatypeCons of
     [info] -> pure info
     _ -> fail "deriveHasField: only supports product types with a single data constructor"
+  when (nameBase constructorInfo.constructorName /= nameBase datatypeInfo.datatypeName) $
+    fail "deriveHasField: type and data constructor must have the same string representation"
   let dropPrefix prefix input = fromMaybe input $ stripPrefix prefix input
   makeDeriveHasField (dropPrefix $ lowerFirst $ nameBase constructorInfo.constructorName) datatypeInfo
 


### PR DESCRIPTION
Right now,

```haskell
data Foo = Bar
  { barX :: X
  , barY :: Y
  }

$(deriveHasField ''Foo)
```

will derive hasfield instances which strip `bar`. However, this could be a confusing default for some people. So, I want to remove this ambiguity. `deriveHasField` will only work when the String representation of a data and type constructor are the same. i.e. the above code will fail to compile.