### PR TITLE
Relax checks for field types, improve support for type variables

### DIFF
--- a/src/DeriveHasField.hs
+++ b/src/DeriveHasField.hs
@@ -81,14 +81,8 @@ makeDeriveHasField fieldModifier datatypeInfo constructorInfo = do
   when (datatypeInfo.datatypeVariant `Foldable.notElem` [Datatype, Newtype]) $
     fail "deriveHasField: only supports data and newtype"
 
-  -- We only support data types with field names and concrete types
-  let isConcreteType = \case
-        ConT _ -> True
-        AppT _ _ -> True
-        _ -> False
+  -- We only support data types with field names
   recordConstructorNames <- getRecordConstructorFieldNames constructorInfo
-  unless (Foldable.all isConcreteType constructorInfo.constructorFields) $
-    fail "deriveHasField: only supports concrete field types"
 
   -- Build the instances
   let constructorNamesAndTypes :: [(Name, Type)]

--- a/test/DeriveHasFieldSpec.hs
+++ b/test/DeriveHasFieldSpec.hs
@@ -48,8 +48,9 @@ someTypePrefix =
     }
 
 data OtherType a b = OtherType
-  { otherTypeField :: Maybe a
-  , otherTypeOtherField :: Either a b
+  { otherTypeField :: a
+  , otherTypeMaybeField :: Maybe a
+  , otherTypeEitherField :: Either a b
   }
 
 DeriveHasField.deriveHasField ''OtherType
@@ -57,8 +58,9 @@ DeriveHasField.deriveHasField ''OtherType
 otherType :: OtherType Int String
 otherType =
   OtherType
-    { otherTypeField = Just 0
-    , otherTypeOtherField = Right "hello"
+    { otherTypeField = 0
+    , otherTypeMaybeField = Just 0
+    , otherTypeEitherField = Right "hello"
     }
 
 data OtherTypePrefix a b = OtherTypePrefix
@@ -126,8 +128,9 @@ spec = do
       someType.someMaybeField `shouldBe` Just 0
       someType.someEitherField `shouldBe` Right 0
     it "compiles and gets the right field" $ do
-      otherType.field `shouldBe` Just 0
-      otherType.otherField `shouldBe` Right "hello"
+      otherType.field `shouldBe` 0
+      otherType.maybeField `shouldBe` Just 0
+      otherType.eitherField `shouldBe` Right "hello"
     it "compiles and gets the right field" $ do
       kindedType.withKind `shouldBe` Just ()
       kindedType.withSymbol `shouldBe` Proxy @"hello"


### PR DESCRIPTION
The upstream fails when the record field is `field :: a`. The reason for that is that its type constructor `VarT` doesn't pass the strict check.

I chose to remove the check for the concrete types altogether for two reasons:
- The types are no longer concrete since #2 got implemented
- If some of the more complex types, e.g, `forall` cause trouble for the code generation, they weren't strictly rejected before too - as long as they are inside of an `AppT`