### PR TITLE
Use Template Haskell test utilities to test failing code

### DIFF
--- a/derive-has-field.cabal
+++ b/derive-has-field.cabal
@@ -48,8 +48,10 @@ test-suite derive-has-field-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      DeriveHasFieldCompilerErrorsSpec
       DeriveHasFieldSpec
       Import
+      Import.Types
       Paths_derive_has_field
   hs-source-dirs:
       test
@@ -66,4 +68,5 @@ test-suite derive-has-field-test
     , hspec >=2.10.10 && <2.11
     , template-haskell >=2.5 && <2.20
     , th-abstraction >0.4 && <0.7
+    , th-test-utils ==1.2.*
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -38,3 +38,4 @@ tests:
     dependencies:
     - derive-has-field
     - hspec >= 2.10.10 && < 2.11
+    - th-test-utils >= 1.2 && < 1.3

--- a/test/DeriveHasFieldCompilerErrorsSpec.hs
+++ b/test/DeriveHasFieldCompilerErrorsSpec.hs
@@ -11,8 +11,81 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+  describe "deriveHasFieldWithPrefix" $ do
+    it "must modify fields when a prefix is requested" $ do
+      result :: Either String [Dec] <-
+        $( do
+            let state =
+                  QState
+                    { mode = MockQ
+                    , knownNames = [("F", ''F)]
+                    , reifyInfo = $(loadNames [''F])
+                    }
+            let result =
+                  tryTestQ
+                    state
+                    (DeriveHasField.deriveHasFieldWithPrefix "world" ''F)
+            [|pure result|]
+         )
+      result
+        `shouldBe` Left "deriveHasField: the given prefix `world` doesn't match the data constructor names"
+
   describe "deriveHasField" $ do
-    it "compiles and gets the right field" $ do
+    it "must be a record with fields" $ do
+      result :: Either String [Dec] <-
+        $( do
+            let state =
+                  QState
+                    { mode = MockQ
+                    , knownNames = [("C", ''C)]
+                    , reifyInfo = $(loadNames [''C])
+                    }
+            let result =
+                  tryTestQ
+                    state
+                    (DeriveHasField.deriveHasField ''C)
+            [|pure result|]
+         )
+      result
+        `shouldBe` Left "deriveHasField: only supports data constructors with field names"
+
+    it "should not be a sum of products" $ do
+      result :: Either String [Dec] <-
+        $( do
+            let state =
+                  QState
+                    { mode = MockQ
+                    , knownNames = [("D", ''D)]
+                    , reifyInfo = $(loadNames [''D])
+                    }
+            let result =
+                  tryTestQ
+                    state
+                    (DeriveHasField.deriveHasField ''D)
+            [|pure result|]
+         )
+      result
+        `shouldBe` Left "deriveHasField: only supports product types with a single data constructor"
+
+    it "must share the same string representation when using deriveHasField" $ do
+      result :: Either String [Dec] <-
+        $( do
+            let state =
+                  QState
+                    { mode = MockQ
+                    , knownNames = [("A", ''A)]
+                    , reifyInfo = $(loadNames [''A])
+                    }
+            let result =
+                  tryTestQ
+                    state
+                    (DeriveHasField.deriveHasField ''A)
+            [|pure result|]
+         )
+      result
+        `shouldBe` Left "deriveHasField: type and data constructor must have the same string representation"
+
+    it "must match record field prefix when using deriveHasField" $ do
       result :: Either String [Dec] <-
         $( do
             let state =

--- a/test/DeriveHasFieldCompilerErrorsSpec.hs
+++ b/test/DeriveHasFieldCompilerErrorsSpec.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module DeriveHasFieldCompilerErrorsSpec (spec) where
+
+import DeriveHasField qualified
+import Import.Types
+import Language.Haskell.TH (Dec)
+import Language.Haskell.TH.TestUtils
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "deriveHasField" $ do
+    it "compiles and gets the right field" $ do
+      result :: Either String [Dec] <-
+        $( do
+            let state =
+                  QState
+                    { mode = MockQ
+                    , knownNames = [("X", ''X)]
+                    , reifyInfo = $(loadNames [''X])
+                    }
+            let result =
+                  tryTestQ
+                    state
+                    (DeriveHasField.deriveHasField ''X)
+            [|pure result|]
+         )
+      result
+        `shouldBe` Left "deriveHasField: the assumed prefix `x` doesn't match the data constructor names"

--- a/test/Import/Types.hs
+++ b/test/Import/Types.hs
@@ -1,0 +1,3 @@
+module Import.Types where
+
+newtype X = X {yHello :: String}

--- a/test/Import/Types.hs
+++ b/test/Import/Types.hs
@@ -1,3 +1,11 @@
 module Import.Types where
 
 newtype X = X {yHello :: String}
+
+newtype A = B {b :: String}
+
+newtype C = C String
+
+data D = D {d :: String} | E {e :: String}
+
+newtype F = F {fHello :: String}


### PR DESCRIPTION
Closes #20 

We have no test coverage around cases that currently are meant to `fail`. Here, I use a library which allows me to test that certain situations do fail and we don't accidentally add regressions to the codebase.

